### PR TITLE
createJavaScriptNode method is obsolete

### DIFF
--- a/public/recorder.js
+++ b/public/recorder.js
@@ -33,7 +33,7 @@
       audioInput = context.createMediaStreamSource(e);
 
       var bufferSize = 2048;
-      recorder = context.createJavaScriptNode(bufferSize, 1, 1);
+      recorder = context.createScriptProcessor(bufferSize, 1, 1);
 
       recorder.onaudioprocess = function(e){
         if(!recording) return;


### PR DESCRIPTION
Important: This method is obsolete, and has been renamed to  AudioContext.createScriptProcessor.
https://developer.mozilla.org/en-US/docs/Web/API/AudioContext.createJavaScriptNode